### PR TITLE
MER: Change the buffer mode of RTSP sources to slave.

### DIFF
--- a/src/plugins/gstreamer/mediaplayer/qgstreamerplayersession.cpp
+++ b/src/plugins/gstreamer/mediaplayer/qgstreamerplayersession.cpp
@@ -1492,6 +1492,7 @@ void QGstreamerPlayerSession::playbinNotifySource(GObject *o, GParamSpec *p, gpo
         //rtspsrc acts like a live source and will therefore only generate data in the PLAYING state.
         self->m_sourceType = RTSPSrc;
         self->m_isLiveSource = true;
+        g_object_set(G_OBJECT(source), "buffer-mode", 1, NULL);
     } else {
         self->m_sourceType = UnknownSrc;
         self->m_isLiveSource = gst_base_src_is_live(GST_BASE_SRC(source));


### PR DESCRIPTION
This is the default in gstreamer 1.0 and doesn't cause the stuttering
apparent with the default buffer mode.

Change-Id: I4241fbe638c176ad93f441a3f76a1041ef1cb6bb
