### PR TITLE
[qtmultimedia] don't play with sink sync property. Contributes to JB#30082

### DIFF
--- a/src/plugins/gstreamer/mediaplayer/qgstreamerplayersession.cpp
+++ b/src/plugins/gstreamer/mediaplayer/qgstreamerplayersession.cpp
@@ -1590,9 +1590,6 @@ void QGstreamerPlayerSession::playbinNotifySource(GObject *o, GParamSpec *p, gpo
         qDebug() << "Current source is a non-live source";
 #endif
 
-    if (self->m_videoSink)
-        g_object_set(G_OBJECT(self->m_videoSink), "sync", !self->m_isLiveSource, NULL);
-
     gst_object_unref(source);
 }
 


### PR DESCRIPTION
I cannot find a reason why someone would flip sync to false and git history
does not say much but in general. Just don't play with it as it can cause an av desync in case we are using a live source
