### PR TITLE
[qtmultimedia] various fixes. Contributes to JB#30862

### DIFF
--- a/src/plugins/gstreamer/camerabin/camerabinsession.cpp
+++ b/src/plugins/gstreamer/camerabin/camerabinsession.cpp
@@ -173,7 +173,7 @@ CameraBinSession::CameraBinSession(GstElementFactory *sourceFactory, QObject *pa
         g_object_set(G_OBJECT(m_camerabin), "flags", envFlags.toInt(), NULL);
 
     //post image preview in RGB format
-    g_object_set(G_OBJECT(m_camerabin), POST_PREVIEWS_PROPERTY, TRUE, NULL);
+    g_object_set(G_OBJECT(m_camerabin), POST_PREVIEWS_PROPERTY, FALSE, NULL);
 
 #if GST_CHECK_VERSION(1,0,0)
     GstCaps *previewCaps = gst_caps_new_simple(

--- a/src/plugins/gstreamer/camerabin/camerabinsession.h
+++ b/src/plugins/gstreamer/camerabin/camerabinsession.h
@@ -180,6 +180,7 @@ public slots:
 private slots:
     void handleViewfinderChange();
     void setupCaptureResolution();
+    void handleBusyChanged(bool busy);
 
 private:
     void load();


### PR DESCRIPTION
2 fixes included. The first one prevents unloading the pipeline while we are still finalizing the recorded file as it might cause the file to be corrupted.

The 2nd fix is mer specific and switches off preview generation until we have support for that in droidcamsrc.
