### PR TITLE
[qtmultimedia] Don't seek to the beginning when we set a new media. Fixes JB#30723

### DIFF
--- a/src/plugins/gstreamer/mediaplayer/qgstreamerplayercontrol.cpp
+++ b/src/plugins/gstreamer/mediaplayer/qgstreamerplayercontrol.cpp
@@ -366,7 +366,7 @@ void QGstreamerPlayerControl::setMedia(const QMediaContent &content, QIODevice *
 
     m_currentState = QMediaPlayer::StoppedState;
     QMediaContent oldMedia = m_currentResource;
-    m_pendingSeekPosition = 0;
+    m_pendingSeekPosition = -1;
     m_session->showPrerollFrames(false); // do not show prerolled frames until pause() or play() explicitly called
     m_setMediaPending = false;
 


### PR DESCRIPTION
There is no need to do any seeking since we will restart the pipeline which will
cause GStreamer to start playback from the beginning. We just invalidate any potential
pending seek request.
