### PR TITLE
[qtmultimedia] don't stop recording pipeline blindly if we are unloading. Fixes JB#32434

### DIFF
--- a/src/plugins/gstreamer/camerabin/camerabincontrol.cpp
+++ b/src/plugins/gstreamer/camerabin/camerabincontrol.cpp
@@ -114,7 +114,7 @@ void CameraBinControl::setState(QCamera::State state)
 
         //special case for stopping the camera while it's busy,
         //it should be delayed until the camera is idle
-        if (state == QCamera::LoadedState &&
+        if ((state == QCamera::LoadedState || state == QCamera::UnloadedState) &&
                 m_session->status() == QCamera::ActiveStatus &&
                 m_session->isBusy()) {
 #ifdef CAMEABIN_DEBUG


### PR DESCRIPTION
This is an extension to commit c09756
If we set the state to Unloaded then the check in setState() for the busy pipeline
will be missed.
